### PR TITLE
Some sidebar changes, updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: File a bug report.
 title: '[Bug] '
-labels: ['bug']
 type: 'Bug'
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report.
-title: '[Bug]: '
+title: '[Bug] '
 labels: ['bug']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: File a bug report.
 title: '[Bug] '
 labels: ['bug']
+type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
 title: '[Feature] '
-labels: ['enhancement']
 type: 'Feature'
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: Suggest an idea for this project
 title: '[Feature] '
 labels: ['enhancement']
+type: 'Feature'
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/gmae_request.yml
+++ b/.github/ISSUE_TEMPLATE/gmae_request.yml
@@ -9,7 +9,7 @@ body:
       label: Gmae Link
       description: A link to where you can play the gmae.
     validations:
-      required: true
+      required: false
   - type: input
     id: gmae-git-link
     attributes:

--- a/.github/ISSUE_TEMPLATE/gmae_request.yml
+++ b/.github/ISSUE_TEMPLATE/gmae_request.yml
@@ -2,7 +2,7 @@ name: Gmae request
 description: Request a gmae to be added
 title: '[Gmae Request] '
 labels: ['gmae', 'enhancement']
-type: "Gmae"
+type: 'Gmae'
 body:
   - type: input
     id: gmae-link

--- a/.github/ISSUE_TEMPLATE/gmae_request.yml
+++ b/.github/ISSUE_TEMPLATE/gmae_request.yml
@@ -2,6 +2,7 @@ name: Gmae request
 description: Request a gmae to be added
 title: '[Gmae Request] '
 labels: ['gmae', 'enhancement']
+type: "Gmae"
 body:
   - type: input
     id: gmae-link

--- a/.github/ISSUE_TEMPLATE/gmae_request.yml
+++ b/.github/ISSUE_TEMPLATE/gmae_request.yml
@@ -1,7 +1,7 @@
 name: Gmae request
 description: Request a gmae to be added
 title: '[Gmae Request] '
-labels: ['gmae', 'enhancement']
+labels: ['gmae']
 type: 'Feature'
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/gmae_request.yml
+++ b/.github/ISSUE_TEMPLATE/gmae_request.yml
@@ -2,7 +2,7 @@ name: Gmae request
 description: Request a gmae to be added
 title: '[Gmae Request] '
 labels: ['gmae', 'enhancement']
-type: 'Gmae'
+type: 'Feature'
 body:
   - type: input
     id: gmae-link

--- a/.github/ISSUE_TEMPLATE/tool_request.yml
+++ b/.github/ISSUE_TEMPLATE/tool_request.yml
@@ -2,6 +2,7 @@ name: Tool request
 description: Request a tool to be added
 title: '[Tool Request] '
 labels: ['tool', 'enhancement']
+type: 'Feature'
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/tool_request.yml
+++ b/.github/ISSUE_TEMPLATE/tool_request.yml
@@ -1,7 +1,7 @@
 name: Tool request
 description: Request a tool to be added
 title: '[Tool Request] '
-labels: ['tool', 'enhancement']
+labels: ['tool']
 type: 'Feature'
 body:
   - type: textarea

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"lint": "prettier --check ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^5.0.0",
+		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.20.3",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"tailwindcss": "^3.4.17",
 		"tailwindcss-animate": "^1.0.7",
 		"typescript": "^5.8.2",
-		"vite": "^6.2.4"
+		"vite": "^6.2.5"
 	},
 	"dependencies": {
 		"@friendofsvelte/tipex": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
-		"svelte": "^5.25.6",
+		"svelte": "^5.25.8",
 		"svelte-check": "^4.1.5",
 		"svelte-sonner": "^0.3.28",
 		"tailwind-merge": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@tailwindcss/typography": "^0.5.16",
 		"@types/md5": "^2.3.5",
 		"autoprefixer": "^10.4.21",
-		"bits-ui": "1.3.16",
+		"bits-ui": "1.3.18",
 		"clsx": "^2.1.1",
 		"lucide-svelte": "^0.487.0",
 		"mode-watcher": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
-		"svelte": "^5.25.8",
+		"svelte": "^5.25.9",
 		"svelte-check": "^4.1.5",
 		"svelte-sonner": "^0.3.28",
 		"tailwind-merge": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@tailwindcss/typography": "^0.5.16",
 		"@types/md5": "^2.3.5",
 		"autoprefixer": "^10.4.21",
-		"bits-ui": "1.3.18",
+		"bits-ui": "1.3.19",
 		"clsx": "^2.1.1",
 		"lucide-svelte": "^0.487.0",
 		"mode-watcher": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.20.3",
+		"@sveltejs/kit": "^2.20.4",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@tailwindcss/typography": "^0.5.16",
 		"@types/md5": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"svelte": "^5.25.8",
 		"svelte-check": "^4.1.5",
 		"svelte-sonner": "^0.3.28",
-		"tailwind-merge": "^3.1.0",
+		"tailwind-merge": "^3.2.0",
 		"tailwind-variants": "^1.0.0",
 		"tailwindcss": "^3.4.17",
 		"tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"tailwind-variants": "^1.0.0",
 		"tailwindcss": "^3.4.17",
 		"tailwindcss-animate": "^1.0.7",
-		"typescript": "^5.8.2",
+		"typescript": "^5.8.3",
 		"vite": "^6.2.5"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"svelte": "^5.25.6",
 		"svelte-check": "^4.1.5",
 		"svelte-sonner": "^0.3.28",
-		"tailwind-merge": "^3.0.2",
+		"tailwind-merge": "^3.1.0",
 		"tailwind-variants": "^1.0.0",
 		"tailwindcss": "^3.4.17",
 		"tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@tailwindcss/typography": "^0.5.16",
 		"@types/md5": "^2.3.5",
 		"autoprefixer": "^10.4.21",
-		"bits-ui": "1.3.13",
+		"bits-ui": "1.3.16",
 		"clsx": "^2.1.1",
 		"lucide-svelte": "^0.487.0",
 		"mode-watcher": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.1)
       bits-ui:
-        specifier: 1.3.16
-        version: 1.3.16(svelte@5.25.8)
+        specifier: 1.3.18
+        version: 1.3.18(svelte@5.25.8)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -685,8 +685,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.3.16:
-    resolution: {integrity: sha512-eBifcu68EspZ1n7mpiyCEjbNAaPoaWLuQZ4aw4lYFt4kJYsOXeAiwKS3+IXwDvYZ9NzBDSSrWbst2k6kKU+8SQ==}
+  bits-ui@1.3.18:
+    resolution: {integrity: sha512-4ZsJqMZUpCEGYMHfVSNZDbOTg3Haxwe01I5LMs4ZImjY7huDac7Dkh2KWTtOdc7jhj2vJprE9bJI4Ayg8gexXQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2019,7 +2019,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.16(svelte@5.25.8):
+  bits-ui@1.3.18(svelte@5.25.8):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.25.6)
       tailwind-merge:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.1.0
+        version: 3.1.0
       tailwind-variants:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@3.4.17)
@@ -1376,6 +1376,9 @@ packages:
 
   tailwind-merge@3.0.2:
     resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
+
+  tailwind-merge@3.1.0:
+    resolution: {integrity: sha512-aV27Oj8B7U/tAOMhJsSGdWqelfmudnGMdXIlMnk1JfsjwSjts6o8HyfN7SFH3EztzH4YH8kk6GbLTHzITJO39Q==}
 
   tailwind-variants@1.0.0:
     resolution: {integrity: sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==}
@@ -2694,6 +2697,8 @@ snapshots:
   tabbable@6.2.0: {}
 
   tailwind-merge@3.0.2: {}
+
+  tailwind-merge@3.1.0: {}
 
   tailwind-variants@1.0.0(tailwindcss@3.4.17):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 0.12.0(svelte@5.25.6)
     devDependencies:
       '@sveltejs/adapter-auto':
-        specifier: ^5.0.0
-        version: 5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        specifier: ^6.0.0
+        version: 6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
         version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
@@ -420,8 +420,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/adapter-auto@5.0.0':
-    resolution: {integrity: sha512-r645Oerr5E9pVX8Xk8ZkObRq/915y5HfZQjFFv4opbstvqQqHfgMhm46tR0iDDKqydZOgJCPa6RdQXh6i7G/2g==}
+  '@sveltejs/adapter-auto@6.0.0':
+    resolution: {integrity: sha512-7mR2/G7vlXakaOj6QBSG9dwBfTgWjV+UnEMB5Z6Xu0ZbdXda6c0su1fNkg0ab0zlilSkloMA2NjCna02/DR7sA==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
@@ -1738,7 +1738,7 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-auto@5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
       '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.1)
       bits-ui:
-        specifier: 1.3.13
-        version: 1.3.13(svelte@5.25.6)
+        specifier: 1.3.16
+        version: 1.3.16(svelte@5.25.6)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -685,8 +685,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.3.13:
-    resolution: {integrity: sha512-0ysKdvHBIArfFBe+MYVAvu5OANOsivk+UJftdiW+e6lGHzf+EW/TZpLh69Vf0n8pYTjkH+33CHlVIImxTZRIMQ==}
+  bits-ui@1.3.16:
+    resolution: {integrity: sha512-eBifcu68EspZ1n7mpiyCEjbNAaPoaWLuQZ4aw4lYFt4kJYsOXeAiwKS3+IXwDvYZ9NzBDSSrWbst2k6kKU+8SQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2016,7 +2016,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.13(svelte@5.25.6):
+  bits-ui@1.3.16(svelte@5.25.6):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,26 +10,26 @@ importers:
     dependencies:
       '@friendofsvelte/tipex':
         specifier: 0.0.7
-        version: 0.0.7(highlight.js@11.8.0)(svelte@5.25.6)
+        version: 0.0.7(highlight.js@11.8.0)(svelte@5.25.8)
       md5:
         specifier: ^2.3.0
         version: 2.3.0
       svelte-persisted-store:
         specifier: ^0.12.0
-        version: 0.12.0(svelte@5.25.6)
+        version: 0.12.0(svelte@5.25.8)
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/kit':
         specifier: ^2.20.3
-        version: 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+        version: 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -41,34 +41,34 @@ importers:
         version: 10.4.21(postcss@8.5.1)
       bits-ui:
         specifier: 1.3.16
-        version: 1.3.16(svelte@5.25.6)
+        version: 1.3.16(svelte@5.25.8)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-svelte:
         specifier: ^0.487.0
-        version: 0.487.0(svelte@5.25.6)
+        version: 0.487.0(svelte@5.25.8)
       mode-watcher:
         specifier: ^0.5.1
-        version: 0.5.1(svelte@5.25.6)
+        version: 0.5.1(svelte@5.25.8)
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.3)(svelte@5.25.6)
+        version: 3.3.3(prettier@3.5.3)(svelte@5.25.8)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.6))(prettier@3.5.3)
+        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8))(prettier@3.5.3)
       svelte:
-        specifier: ^5.25.6
-        version: 5.25.6
+        specifier: ^5.25.8
+        version: 5.25.8
       svelte-check:
         specifier: ^4.1.5
-        version: 4.1.5(svelte@5.25.6)(typescript@5.8.2)
+        version: 4.1.5(svelte@5.25.8)(typescript@5.8.2)
       svelte-sonner:
         specifier: ^0.3.28
-        version: 0.3.28(svelte@5.25.6)
+        version: 0.3.28(svelte@5.25.8)
       tailwind-merge:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1367,8 +1367,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte@5.25.6:
-    resolution: {integrity: sha512-RGkaeAXDuJdvhA1fdSM5GgD++vYfJYijZL0uN6kM2s/TRJ663jktBhZlF0qjzAJGR/34PtaeT3G8MKJY1EKeqg==}
+  svelte@5.25.8:
+    resolution: {integrity: sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==}
     engines: {node: '>=18'}
 
   tabbable@6.2.0:
@@ -1604,7 +1604,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@friendofsvelte/tipex@0.0.7(highlight.js@11.8.0)(svelte@5.25.6)':
+  '@friendofsvelte/tipex@0.0.7(highlight.js@11.8.0)(svelte@5.25.8)':
     dependencies:
       '@tiptap/core': 2.11.5(@tiptap/pm@2.11.5)
       '@tiptap/extension-code-block': 2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5)
@@ -1617,7 +1617,7 @@ snapshots:
       '@tiptap/starter-kit': 2.11.5
       iconify-icon: 1.0.8
       lowlight: 2.9.0
-      svelte: 5.25.6
+      svelte: 5.25.8
     transitivePeerDependencies:
       - highlight.js
 
@@ -1738,18 +1738,18 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
 
-  '@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -1761,26 +1761,26 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
-      svelte: 5.25.6
+      svelte: 5.25.8
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
-      svelte: 5.25.6
+      svelte: 5.25.8
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.25.6
+      svelte: 5.25.8
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
       vitefu: 1.0.5(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
     transitivePeerDependencies:
@@ -2019,15 +2019,15 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.16(svelte@5.25.6):
+  bits-ui@1.3.16(svelte@5.25.8):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13
       '@internationalized/date': 3.7.0
       esm-env: 1.2.2
-      runed: 0.23.4(svelte@5.25.6)
-      svelte: 5.25.6
-      svelte-toolbelt: 0.7.1(svelte@5.25.6)
+      runed: 0.23.4(svelte@5.25.8)
+      svelte: 5.25.8
+      svelte-toolbelt: 0.7.1(svelte@5.25.8)
       tabbable: 6.2.0
 
   brace-expansion@2.0.1:
@@ -2280,9 +2280,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-svelte@0.487.0(svelte@5.25.6):
+  lucide-svelte@0.487.0(svelte@5.25.8):
     dependencies:
-      svelte: 5.25.6
+      svelte: 5.25.8
 
   magic-string@0.30.17:
     dependencies:
@@ -2318,9 +2318,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mode-watcher@0.5.1(svelte@5.25.6):
+  mode-watcher@0.5.1(svelte@5.25.8):
     dependencies:
-      svelte: 5.25.6
+      svelte: 5.25.8
 
   mri@1.2.0: {}
 
@@ -2417,16 +2417,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.6):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8):
     dependencies:
       prettier: 3.5.3
-      svelte: 5.25.6
+      svelte: 5.25.8
 
-  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.6))(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8))(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.5.3)(svelte@5.25.6)
+      prettier-plugin-svelte: 3.3.3(prettier@3.5.3)(svelte@5.25.8)
 
   prettier@3.5.3: {}
 
@@ -2587,10 +2587,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.23.4(svelte@5.25.6):
+  runed@0.23.4(svelte@5.25.8):
     dependencies:
       esm-env: 1.2.2
-      svelte: 5.25.6
+      svelte: 5.25.8
 
   sade@1.8.1:
     dependencies:
@@ -2650,34 +2650,34 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.1.5(svelte@5.25.6)(typescript@5.8.2):
+  svelte-check@4.1.5(svelte@5.25.8)(typescript@5.8.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.4.3
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.25.6
+      svelte: 5.25.8
       typescript: 5.8.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte-persisted-store@0.12.0(svelte@5.25.6):
+  svelte-persisted-store@0.12.0(svelte@5.25.8):
     dependencies:
-      svelte: 5.25.6
+      svelte: 5.25.8
 
-  svelte-sonner@0.3.28(svelte@5.25.6):
+  svelte-sonner@0.3.28(svelte@5.25.8):
     dependencies:
-      svelte: 5.25.6
+      svelte: 5.25.8
 
-  svelte-toolbelt@0.7.1(svelte@5.25.6):
+  svelte-toolbelt@0.7.1(svelte@5.25.8):
     dependencies:
       clsx: 2.1.1
-      runed: 0.23.4(svelte@5.25.6)
+      runed: 0.23.4(svelte@5.25.8)
       style-to-object: 1.0.8
-      svelte: 5.25.6
+      svelte: 5.25.8
 
-  svelte@5.25.6:
+  svelte@5.25.8:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.25.8)
       tailwind-merge:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.2.0
+        version: 3.2.0
       tailwind-variants:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@3.4.17)
@@ -1377,8 +1377,8 @@ packages:
   tailwind-merge@3.0.2:
     resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
-  tailwind-merge@3.1.0:
-    resolution: {integrity: sha512-aV27Oj8B7U/tAOMhJsSGdWqelfmudnGMdXIlMnk1JfsjwSjts6o8HyfN7SFH3EztzH4YH8kk6GbLTHzITJO39Q==}
+  tailwind-merge@3.2.0:
+    resolution: {integrity: sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==}
 
   tailwind-variants@1.0.0:
     resolution: {integrity: sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==}
@@ -2698,7 +2698,7 @@ snapshots:
 
   tailwind-merge@3.0.2: {}
 
-  tailwind-merge@3.1.0: {}
+  tailwind-merge@3.2.0: {}
 
   tailwind-variants@1.0.0(tailwindcss@3.4.17):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/kit':
-        specifier: ^2.20.3
-        version: 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+        specifier: ^2.20.4
+        version: 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
         version: 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
@@ -430,8 +430,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.20.3':
-    resolution: {integrity: sha512-z1SQ8qra/kGY3DzarG7xc6XsbKm8UY3SnI82XLI3PqMYWbYj/LpjPWuAz9WA5EyLjFNLD7sOAOEW8Gt4yjr5Vg==}
+  '@sveltejs/kit@2.20.4':
+    resolution: {integrity: sha512-B3Y1mb1Qjt57zXLVch5tfqsK/ebHe6uYTcFSnGFNwRpId3+fplLgQK6Z2zhDVBezSsPuhDq6Pry+9PA88ocN6Q==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -1738,16 +1738,16 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
 
-  '@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,26 +10,26 @@ importers:
     dependencies:
       '@friendofsvelte/tipex':
         specifier: 0.0.7
-        version: 0.0.7(highlight.js@11.8.0)(svelte@5.25.8)
+        version: 0.0.7(highlight.js@11.8.0)(svelte@5.25.9)
       md5:
         specifier: ^2.3.0
         version: 2.3.0
       svelte-persisted-store:
         specifier: ^0.12.0
-        version: 0.12.0(svelte@5.25.8)
+        version: 0.12.0(svelte@5.25.9)
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
+        version: 3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/kit':
         specifier: ^2.20.4
-        version: 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+        version: 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -41,34 +41,34 @@ importers:
         version: 10.4.21(postcss@8.5.1)
       bits-ui:
         specifier: 1.3.18
-        version: 1.3.18(svelte@5.25.8)
+        version: 1.3.18(svelte@5.25.9)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-svelte:
         specifier: ^0.487.0
-        version: 0.487.0(svelte@5.25.8)
+        version: 0.487.0(svelte@5.25.9)
       mode-watcher:
         specifier: ^0.5.1
-        version: 0.5.1(svelte@5.25.8)
+        version: 0.5.1(svelte@5.25.9)
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.3)(svelte@5.25.8)
+        version: 3.3.3(prettier@3.5.3)(svelte@5.25.9)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8))(prettier@3.5.3)
+        version: 0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.9))(prettier@3.5.3)
       svelte:
-        specifier: ^5.25.8
-        version: 5.25.8
+        specifier: ^5.25.9
+        version: 5.25.9
       svelte-check:
         specifier: ^4.1.5
-        version: 4.1.5(svelte@5.25.8)(typescript@5.8.3)
+        version: 4.1.5(svelte@5.25.9)(typescript@5.8.3)
       svelte-sonner:
         specifier: ^0.3.28
-        version: 0.3.28(svelte@5.25.8)
+        version: 0.3.28(svelte@5.25.9)
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1367,8 +1367,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte@5.25.8:
-    resolution: {integrity: sha512-yRmjmT5rgCZUMfCKS5varGlSe/nQyr2oClyIirbBChfTFc00YjVAyVWo1zOH74La3hi5KRSkNJKncyJ04PwIYA==}
+  svelte@5.25.9:
+    resolution: {integrity: sha512-/SSLuHty7ktD8WwDDy3bjuijeNK+9etPz5lzPwe+AariSvk/8s9YLtot3j9/W6CK2iGH347S5RHXAE4HavJS+Q==}
     engines: {node: '>=18'}
 
   tabbable@6.2.0:
@@ -1604,7 +1604,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@friendofsvelte/tipex@0.0.7(highlight.js@11.8.0)(svelte@5.25.8)':
+  '@friendofsvelte/tipex@0.0.7(highlight.js@11.8.0)(svelte@5.25.9)':
     dependencies:
       '@tiptap/core': 2.11.5(@tiptap/pm@2.11.5)
       '@tiptap/extension-code-block': 2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5)
@@ -1617,7 +1617,7 @@ snapshots:
       '@tiptap/starter-kit': 2.11.5
       iconify-icon: 1.0.8
       lowlight: 2.9.0
-      svelte: 5.25.8
+      svelte: 5.25.9
     transitivePeerDependencies:
       - highlight.js
 
@@ -1738,18 +1738,18 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
 
-  '@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/kit@2.20.4(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -1761,26 +1761,26 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
-      svelte: 5.25.8
+      svelte: 5.25.9
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
-      svelte: 5.25.8
+      svelte: 5.25.9
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.8)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.9)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.25.8
+      svelte: 5.25.9
       vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
       vitefu: 1.0.5(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
     transitivePeerDependencies:
@@ -2019,15 +2019,15 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.18(svelte@5.25.8):
+  bits-ui@1.3.18(svelte@5.25.9):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13
       '@internationalized/date': 3.7.0
       esm-env: 1.2.2
-      runed: 0.23.4(svelte@5.25.8)
-      svelte: 5.25.8
-      svelte-toolbelt: 0.7.1(svelte@5.25.8)
+      runed: 0.23.4(svelte@5.25.9)
+      svelte: 5.25.9
+      svelte-toolbelt: 0.7.1(svelte@5.25.9)
       tabbable: 6.2.0
 
   brace-expansion@2.0.1:
@@ -2280,9 +2280,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-svelte@0.487.0(svelte@5.25.8):
+  lucide-svelte@0.487.0(svelte@5.25.9):
     dependencies:
-      svelte: 5.25.8
+      svelte: 5.25.9
 
   magic-string@0.30.17:
     dependencies:
@@ -2318,9 +2318,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mode-watcher@0.5.1(svelte@5.25.8):
+  mode-watcher@0.5.1(svelte@5.25.9):
     dependencies:
-      svelte: 5.25.8
+      svelte: 5.25.9
 
   mri@1.2.0: {}
 
@@ -2417,16 +2417,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.9):
     dependencies:
       prettier: 3.5.3
-      svelte: 5.25.8
+      svelte: 5.25.9
 
-  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.8))(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.6.11(prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.25.9))(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.3.3(prettier@3.5.3)(svelte@5.25.8)
+      prettier-plugin-svelte: 3.3.3(prettier@3.5.3)(svelte@5.25.9)
 
   prettier@3.5.3: {}
 
@@ -2587,10 +2587,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.23.4(svelte@5.25.8):
+  runed@0.23.4(svelte@5.25.9):
     dependencies:
       esm-env: 1.2.2
-      svelte: 5.25.8
+      svelte: 5.25.9
 
   sade@1.8.1:
     dependencies:
@@ -2650,34 +2650,34 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.1.5(svelte@5.25.8)(typescript@5.8.3):
+  svelte-check@4.1.5(svelte@5.25.9)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.4.3
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.25.8
+      svelte: 5.25.9
       typescript: 5.8.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-persisted-store@0.12.0(svelte@5.25.8):
+  svelte-persisted-store@0.12.0(svelte@5.25.9):
     dependencies:
-      svelte: 5.25.8
+      svelte: 5.25.9
 
-  svelte-sonner@0.3.28(svelte@5.25.8):
+  svelte-sonner@0.3.28(svelte@5.25.9):
     dependencies:
-      svelte: 5.25.8
+      svelte: 5.25.9
 
-  svelte-toolbelt@0.7.1(svelte@5.25.8):
+  svelte-toolbelt@0.7.1(svelte@5.25.9):
     dependencies:
       clsx: 2.1.1
-      runed: 0.23.4(svelte@5.25.8)
+      runed: 0.23.4(svelte@5.25.9)
       style-to-object: 1.0.8
-      svelte: 5.25.8
+      svelte: 5.25.9
 
-  svelte@5.25.8:
+  svelte@5.25.9:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.25.8
       svelte-check:
         specifier: ^4.1.5
-        version: 4.1.5(svelte@5.25.8)(typescript@5.8.2)
+        version: 4.1.5(svelte@5.25.8)(typescript@5.8.3)
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.25.8)
@@ -82,8 +82,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
       vite:
         specifier: ^6.2.5
         version: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
@@ -1420,8 +1420,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2650,7 +2650,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.1.5(svelte@5.25.8)(typescript@5.8.2):
+  svelte-check@4.1.5(svelte@5.25.8)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
@@ -2658,7 +2658,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.25.8
-      typescript: 5.8.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - picomatch
 
@@ -2758,7 +2758,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.8.2: {}
+  typescript@5.8.3: {}
 
   uc.micro@2.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,16 +20,16 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^5.0.0
-        version: 5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))
+        version: 5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))
+        version: 3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/kit':
         specifier: ^2.20.3
-        version: 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+        version: 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -85,8 +85,8 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
       vite:
-        specifier: ^6.2.4
-        version: 6.2.4(jiti@1.21.7)(yaml@2.7.0)
+        specifier: ^6.2.5
+        version: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
 
 packages:
 
@@ -1434,8 +1434,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite@6.2.4:
-    resolution: {integrity: sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==}
+  vite@6.2.5:
+    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1735,18 +1735,18 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/adapter-auto@5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-auto@5.0.0(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/kit': 2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
 
-  '@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/kit@2.20.3(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -1759,27 +1759,27 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.25.6
-      vite: 6.2.4(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       svelte: 5.25.6
-      vite: 6.2.4(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.25.6)(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.25.6
-      vite: 6.2.4(jiti@1.21.7)(yaml@2.7.0)
-      vitefu: 1.0.5(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0))
+      vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
+      vitefu: 1.0.5(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -2765,7 +2765,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@6.2.4(jiti@1.21.7)(yaml@2.7.0):
+  vite@6.2.5(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -2775,9 +2775,9 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.7.0
 
-  vitefu@1.0.5(vite@6.2.4(jiti@1.21.7)(yaml@2.7.0)):
+  vitefu@1.0.5(vite@6.2.5(jiti@1.21.7)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.2.4(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.2.5(jiti@1.21.7)(yaml@2.7.0)
 
   w3c-keyname@2.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.1)
       bits-ui:
-        specifier: 1.3.18
-        version: 1.3.18(svelte@5.25.9)
+        specifier: 1.3.19
+        version: 1.3.19(svelte@5.25.9)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -685,8 +685,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.3.18:
-    resolution: {integrity: sha512-4ZsJqMZUpCEGYMHfVSNZDbOTg3Haxwe01I5LMs4ZImjY7huDac7Dkh2KWTtOdc7jhj2vJprE9bJI4Ayg8gexXQ==}
+  bits-ui@1.3.19:
+    resolution: {integrity: sha512-2blb6dkgedHUsDXqCjvmtUi4Advgd9MhaJDT8r7bEWDzHI8HGsOoYsLeh8CxpEWWEYPrlGN+7k+kpxRhIDdFrQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2019,7 +2019,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.18(svelte@5.25.9):
+  bits-ui@1.3.19(svelte@5.25.9):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -254,7 +254,7 @@
 			</Sidebar.Menu>
 		</Sidebar.Group>
 	</Sidebar.Content>
-	<Sidebar.Footer>
+	<Sidebar.Footer class="[&>li]:list-none">
 		{#if $preferencesStore.experimentalFeatures === true}
 			<Sidebar.MenuItem>
 				<Sidebar.MenuButton>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,8 +28,9 @@
 <Toaster />
 <ModeWatcher defaultMode={'dark'} />
 <Settings />
-<Sidebar.Provider>
+<Sidebar.Provider class="flex flex-col md:flex-row">
 	<AppSidebar />
+	<Sidebar.Trigger class="m-1 p-1 md:hidden" />
 	<Sidebar.Inset>
 		{@render children()}
 	</Sidebar.Inset>


### PR DESCRIPTION
This pull request includes updates to issue templates and dependency versions. The most important changes include adding a new `type` field to issue templates and updating several dependencies in `package.json` and `pnpm-lock.yaml` to their latest versions.

### Updates to issue templates:
* [`.github/ISSUE_TEMPLATE/bug_report.yml`](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL3-R4): Added `type: 'Bug'` field.
* [`.github/ISSUE_TEMPLATE/feature_request.yml`](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL4-R4): Added `type: 'Feature'` field.
* [`.github/ISSUE_TEMPLATE/gmae_request.yml`](diffhunk://#diff-129d3ef6e857c100abff016b70dc8c1115364aefcc9bccfffb12befc556f5a8bL4-R13): Added `type: 'Feature'` field and changed `required` validation to `false` for `gmae-link`.
* [`.github/ISSUE_TEMPLATE/tool_request.yml`](diffhunk://#diff-276e481aba6194e72bbe46748581c8c2afeb01c71218371cad3c629b7d163064L4-R5): Added `type: 'Feature'` field.

### Dependency updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R38): Updated versions for `@sveltejs/adapter-auto`, `@sveltejs/kit`, `bits-ui`, `svelte`, `tailwind-merge`, `typescript`, and `vite`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13-R32): Corresponding updates to dependency versions to match `package.json` changes, including updates for `svelte`, `@sveltejs/kit`, `bits-ui`, `tailwind-merge`, and `typescript`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13-R32) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL43-R74) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL85-R89) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL423-R424) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL433-R434) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL688-R689) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1370-R1371) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1380-R1382) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1420-R1424) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1437-R1441) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1604-R1607) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1617-R1620) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1738-R1752) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1761-R1785) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2019-R2030) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2280-R2285) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2318-R2323) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2417-R2429) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2587-R2593) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2650-R2680)