### PR TITLE
add menu items and pages

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -52,7 +52,7 @@
 		url: string;
 		icon?: any;
 		experimental: boolean;
-		items: {
+		items?: {
 			title: string;
 			url: string;
 		}[];
@@ -241,37 +241,39 @@
 										{#if open}
 											<div {...props} transition:slide>
 												<Sidebar.MenuSub>
-													{#each groupItem.items as item (item.title)}
-														<Sidebar.MenuSubItem>
-															<Sidebar.MenuSubButton
-																isActive={item.url === page.url.pathname ||
-																	(item.url === '/' && page.url.pathname === '')}
-															>
-																{#snippet child({ props })}
-																	<a
-																		href={item.url}
-																		onclick={() => {
-																			sidebar.setOpenMobile(false);
-																		}}
-																		{...props}
-																		class={clsx(
-																			'group/link z-50 text-nowrap hover:overflow-visible',
-																			props.class || ''
-																		)}
-																		target={item.url.startsWith('http') ? '_blank' : undefined}
-																		rel={item.url.startsWith('http')
-																			? 'noopener noreferrer'
-																			: undefined}
-																	>
-																		{item.title}
-																		<div
-																			class="to-sidebar absolute right-0 h-full w-[25%] bg-gradient-to-r from-transparent group-hover/link:opacity-0"
-																		></div>
-																	</a>
-																{/snippet}
-															</Sidebar.MenuSubButton>
-														</Sidebar.MenuSubItem>
-													{/each}
+													{#if groupItem.items}
+														{#each groupItem.items as item (item.title)}
+															<Sidebar.MenuSubItem>
+																<Sidebar.MenuSubButton
+																	isActive={item.url === page.url.pathname ||
+																		(item.url === '/' && page.url.pathname === '')}
+																>
+																	{#snippet child({ props })}
+																		<a
+																			href={item.url}
+																			onclick={() => {
+																				sidebar.setOpenMobile(false);
+																			}}
+																			{...props}
+																			class={clsx(
+																				'group/link z-50 text-nowrap hover:overflow-visible',
+																				props.class || ''
+																			)}
+																			target={item.url.startsWith('http') ? '_blank' : undefined}
+																			rel={item.url.startsWith('http')
+																				? 'noopener noreferrer'
+																				: undefined}
+																		>
+																			{item.title}
+																			<div
+																				class="to-sidebar absolute right-0 h-full w-[25%] bg-gradient-to-r from-transparent group-hover/link:opacity-0"
+																			></div>
+																		</a>
+																	{/snippet}
+																</Sidebar.MenuSubButton>
+															</Sidebar.MenuSubItem>
+														{/each}
+													{/if}
 												</Sidebar.MenuSub>
 											</div>
 										{/if}

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -22,6 +22,9 @@
 	import Code from 'lucide-svelte/icons/code';
 	import Settings from 'lucide-svelte/icons/settings';
 	import PanelLeft from 'lucide-svelte/icons/panel-left';
+	import Copy from 'lucide-svelte/icons/copy';
+	import Server from 'lucide-svelte/icons/server';
+	import Info from 'lucide-svelte/icons/info';
 
 	// App state and data
 	import { preferencesStore } from '$lib/stores';
@@ -113,6 +116,24 @@
 						url: `/g/${gmae.id}`
 					}))
 				]
+			},
+			{
+				title: 'Mirrors',
+				experimental: true,
+				url: '/mirrors',
+				icon: Copy
+			},
+			{
+				title: 'Host a mirror',
+				experimental: true,
+				icon: Server,
+				url: '/mirrors/host'
+			},
+			{
+				title: 'About',
+				experimental: true,
+				icon: Info,
+				url: '/about'
 			}
 		].filter((item) => !item.experimental || $preferencesStore.experimentalFeatures)
 	);

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -62,8 +62,7 @@
 				title: 'Home',
 				icon: Home,
 				url: '/',
-				experimental: false,
-				items: []
+				experimental: false
 			},
 			{
 				title: 'Tools',

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,0 +1,4 @@
+<div class="container mx-auto flex flex-col p-3">
+	<h1 class="text-3xl">About</h1>
+	Coming soon
+</div>

--- a/src/routes/mirrors/+page.svelte
+++ b/src/routes/mirrors/+page.svelte
@@ -1,0 +1,6 @@
+<iframe
+	src="https://educationaltools.github.io/status/"
+	title="Status"
+	frameborder="0"
+	class="h-full w-full"
+></iframe>

--- a/src/routes/mirrors/host/+page.svelte
+++ b/src/routes/mirrors/host/+page.svelte
@@ -1,0 +1,4 @@
+<div class="container mx-auto flex flex-col p-3">
+	<h1 class="text-3xl">Host a mirror</h1>
+	Coming soon
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three new experimental sidebar menu items: "Mirrors", "Host a mirror", and "About", each with distinct icons.
  - Introduced new pages for "Mirrors" (showing an embedded status page), "Host a mirror", and "About", with placeholder or embedded content.
- **Bug Fixes**
  - Improved sidebar stability by ensuring submenu rendering only occurs when items exist, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->