### PR TITLE
Use set git identity for vercel deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,8 @@ jobs:
           external_repository: 'Inglan/EduTools-Vercel'
           publish_branch: main # default: gh-pages
           publish_dir: ./build
+          user_name: 'Ingo Wolf'
+          user_email: 'me@ingowolf.au'
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
Fixes issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to include specific user name and email for deployment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->