### PR TITLE
use a reverse proxy for posthog analytics

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,7 +8,7 @@ export function initializeAnalytics() {
 	if (!browser) return;
 
 	posthog.init('phc_jg4gOdigfHQD4MSgrSaO883dp2LjNJbJO7azv61UtI0', {
-		api_host: 'https://us.i.posthog.com',
+		api_host: 'https://hog.edutools.ingo.au',
 		person_profiles: 'always',
 		capture_exceptions: true
 	});
@@ -18,7 +18,7 @@ export async function checkTrackerBlocked(): Promise<boolean> {
 	if (!browser) return false;
 
 	try {
-		await fetch('https://us-assets.i.posthog.com/static/exception-autocapture.js');
+		await fetch('https://hog.edutools.ingo.au/static/exception-autocapture.js');
 		return false;
 	} catch {
 		return navigator.onLine;

--- a/src/lib/components/tracker-dialog.svelte
+++ b/src/lib/components/tracker-dialog.svelte
@@ -12,10 +12,17 @@
 		<Dialog.Title>Notice</Dialog.Title>
 		<Dialog.Description>
 			We use PostHog to detect/fix errors, track usage and roll out features. Please disable your
-			tracker/ad blocker to allow this. Don't worry, we won't show you any ads.
-			<br /><br />
+			tracker/ad blocker for this site to allow this. Don't worry, we won't show you any ads.
+			<br />
+			<br />
 			For more details about our data collection practices, see our
 			<a href="/privacy" class="text-blue-600 hover:underline" target="_blank">Privacy Policy</a>.
+			<br />
+			<br />
+			<details>
+				<summary>Techinal info</summary>
+				<p>We detected that hog.edutools.ingo.au is blocked by your ad/tracker blocker</p>
+			</details>
 		</Dialog.Description>
 		<Dialog.Footer>
 			<Dialog.Close onclick={() => ($trackerDialogClosed = true)}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tracker dialog now includes a “Technical info” section that indicates when our services are being blocked, helping users diagnose issues.
  - Updated notice text for clearer guidance on allowing trackers/ad blockers for this site.

- Style
  - Improved spacing in the tracker dialog for better readability.

- Chores
  - Updated analytics service endpoints to a new host; no changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->